### PR TITLE
added forced clearing of async results before the next query…

### DIFF
--- a/guile-dbd-postgresql/src/guile-dbd-postgresql.c
+++ b/guile-dbd-postgresql/src/guile-dbd-postgresql.c
@@ -245,13 +245,11 @@ __postgresql_query_g_db_handle(gdbi_db_handle_t* dbh, char* query)
 
   do
     {
-  if (pgsqlP->res)
-    {
-      PQclear(pgsqlP->res);
-      pgsqlP->res = NULL;
-    }
-      else
-        break;
+      if (pgsqlP->res)
+        {
+          PQclear(pgsqlP->res);
+          pgsqlP->res = NULL;
+        }
     }
   while ((pgsqlP->res = PQgetResult(pgsqlP->pgsql)) != NULL); 
 

--- a/guile-dbd-postgresql/src/guile-dbd-postgresql.c
+++ b/guile-dbd-postgresql/src/guile-dbd-postgresql.c
@@ -367,7 +367,14 @@ __postgresql_getrow_g_db_handle(gdbi_db_handle_t* dbh)
                type == 701 )  /* float8 */
         {
           const char * vstr = PQgetvalue(pgsqlP->res, pgsqlP->lget, f);
-          value = scm_from_double(atof(vstr));
+          if (vstr && *vstr)
+            { 
+              value = scm_c_locale_stringn_to_number(vstr, strlen(vstr), 10);
+            }
+          else
+            {
+              value = scm_from_double(0.0);
+            }
         }
       else if (type == 1005 || /* _int2  -- list of integers */
                type == 1007 || /* _int4  -- list of integers */


### PR DESCRIPTION
According to documentation of libpq, the results of async query should be all read up before the next query.
Additionally, numeric type is now considered as floating point.